### PR TITLE
Add Default CSS Value

### DIFF
--- a/src/styles/reading-style.css
+++ b/src/styles/reading-style.css
@@ -97,6 +97,9 @@
 
   --reading-font-monospace: "Roboto Mono VF", "SFMono-Regular", Consolas,
     "Liberation Mono", Menlo, Courier, monospace;
+
+  /* Text selection colour */
+  --text-selection-background-color: #3297FD /* default value chosen from https://stackoverflow.com/questions/16094837/what-is-the-browser-default-background-color-when-selecting-text */
 }
 
 .reading-content {


### PR DESCRIPTION
CSS variable is used here without a default value set in `:root`:
https://github.com/zhanglun/lettura/blob/7a66c923b1b9f7604d9a96b9556817ddcdb9b6ad/src/styles/reading-style.css#L112-L114

This results in selections being invisible.

Alternatively, since this css variable is not modified anywhere in the code, removing the `::selection` entirely is an option, which would then use the system's default colours, but I figured you added it with the plan of it being configurable in the future.