### PR TITLE
fix: colour scheme not persisting & incorrect initialization

### DIFF
--- a/src-tauri/src/core/config.rs
+++ b/src-tauri/src/core/config.rs
@@ -5,6 +5,16 @@ use std::{env, fs, path, path::PathBuf};
 use toml;
 
 #[derive(Debug, Serialize, Deserialize)]
+pub enum ColorScheme {
+  #[serde(rename = "light")]
+  Light,
+  #[serde(rename = "dark")]
+  Dark,
+  #[serde(rename = "system")]
+  System,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LocalProxy {
   pub ip: String,
   pub port: String,
@@ -57,7 +67,7 @@ macro_rules! generate_set_property {
 pub struct UserConfig {
   pub threads: i32,
   pub theme: String,
-  pub color_scheme: String,
+  pub color_scheme: ColorScheme,
 
   pub update_interval: u64,
   pub last_sync_time: String,
@@ -73,7 +83,7 @@ impl Default for UserConfig {
     Self {
       threads: 1,
       theme: String::from('1'),
-      color_scheme: String::from("system"),
+      color_scheme: ColorScheme::System,
       update_interval: 0,
       last_sync_time: Utc.timestamp_millis_opt(0).unwrap().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
       local_proxy: None,
@@ -190,7 +200,7 @@ pub fn load_or_initial() -> Option<UserConfig> {
   }
 
   if !data.contains_key("color_scheme") {
-    data.insert(String::from("color_scheme"), toml::Value::try_from::<String>(String::from("system")).unwrap());
+    data.insert(String::from("color_scheme"), toml::Value::try_from::<ColorScheme>(ColorScheme::System).unwrap());
   }
 
   if !data.contains_key("update_interval") {

--- a/src-tauri/src/core/config.rs
+++ b/src-tauri/src/core/config.rs
@@ -57,6 +57,7 @@ macro_rules! generate_set_property {
 pub struct UserConfig {
   pub threads: i32,
   pub theme: String,
+  pub color_scheme: String,
 
   pub update_interval: u64,
   pub last_sync_time: String,
@@ -72,6 +73,7 @@ impl Default for UserConfig {
     Self {
       threads: 1,
       theme: String::from('1'),
+      color_scheme: String::from("system"),
       update_interval: 0,
       last_sync_time: Utc.timestamp_millis_opt(0).unwrap().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
       local_proxy: None,
@@ -187,8 +189,8 @@ pub fn load_or_initial() -> Option<UserConfig> {
     data.insert(String::from("theme"), toml::Value::try_from::<String>(String::from("system")).unwrap());
   }
 
-  if !data.contains_key("theme") {
-    data.insert(String::from("theme"), toml::Value::try_from::<String>(String::from("default")).unwrap());
+  if !data.contains_key("color_scheme") {
+    data.insert(String::from("color_scheme"), toml::Value::try_from::<String>(String::from("system")).unwrap());
   }
 
   if !data.contains_key("update_interval") {

--- a/src-tauri/src/server/handlers/common.rs
+++ b/src-tauri/src/server/handlers/common.rs
@@ -15,6 +15,7 @@ pub async fn handle_get_user_config() -> Result<impl Responder> {
 
 #[post("/api/user-config")]
 pub async fn handle_update_user_config(user_cfg: web::Json<config::UserConfig>) -> Result<impl Responder> {
+  log::info!("===> USER CONFIG {:?}", user_cfg);
   let result = config::update_user_config(user_cfg.0);
   Ok(web::Json(result))
 }

--- a/src-tauri/src/server/handlers/common.rs
+++ b/src-tauri/src/server/handlers/common.rs
@@ -15,7 +15,6 @@ pub async fn handle_get_user_config() -> Result<impl Responder> {
 
 #[post("/api/user-config")]
 pub async fn handle_update_user_config(user_cfg: web::Json<config::UserConfig>) -> Result<impl Responder> {
-  log::info!("===> USER CONFIG {:?}", user_cfg);
   let result = config::update_user_config(user_cfg.0);
   Ok(web::Json(result))
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,16 +37,16 @@ function App() {
 
   useEffect(() => {
     store.getUserConfig().then((cfg: UserConfig) => {
-      const { theme, customize_style } = cfg;
+      const { color_scheme, customize_style } = cfg;
 
-      if (theme === "system") {
+      if (color_scheme === "system") {
         document.documentElement.dataset.colorScheme = window.matchMedia(
           "(prefers-color-scheme: dark)"
         ).matches
           ? "dark"
           : "light";
       } else {
-        document.documentElement.dataset.colorScheme = theme;
+        document.documentElement.dataset.colorScheme = color_scheme;
       }
 
       customize_style &&

--- a/src/layout/Setting/Appearance/ColorScheme.tsx
+++ b/src/layout/Setting/Appearance/ColorScheme.tsx
@@ -28,7 +28,7 @@ export const ColorScheme = () => {
           className={clsx(
             "border rounded-lg h-14 flex cursor-pointer items-center justify-center dark:bg-foreground dark:text-background",
             {
-              "ring-2": store.userConfig.theme === "light",
+              "ring-2": store.userConfig.color_scheme === "light",
             }
           )}
           onClick={() => handleThemeChange("light")}
@@ -44,7 +44,7 @@ export const ColorScheme = () => {
             "bg-foreground text-background",
             "dark:bg-background dark:text-foreground",
             {
-              "ring-2": store.userConfig.theme === "dark",
+              "ring-2": store.userConfig.color_scheme === "dark",
             }
           )}
           onClick={() => handleThemeChange("dark")}
@@ -60,7 +60,7 @@ export const ColorScheme = () => {
             "bg-gradient-to-br from-background from-50%  via-foreground via-0% to-foreground",
             "dark:from-foreground dark:from-50% dark:via-background dark:via-0% dark:to-background",
             {
-              "ring-2": store.userConfig.theme === "system",
+              "ring-2": store.userConfig.color_scheme === "system",
             }
           )}
           onClick={() => handleThemeChange("system")}


### PR DESCRIPTION
### Fixed Issues:
1. After changing your colour scheme and restarting the application, your colour scheme would not persist.
2. The selection ring around the currently selected colour scheme was being incorrectly applied
3. Initialization of colour scheme was incorrect

### Cause 1:
After the client sends a `POST` request to this endpoint
https://github.com/zhanglun/lettura/blob/7a66c923b1b9f7604d9a96b9556817ddcdb9b6ad/src-tauri/src/server/handlers/common.rs#L16-L20
the payload is deserialized incorrectly due to missing field `color_scheme` in the `UserConfig` struct:
https://github.com/zhanglun/lettura/blob/7a66c923b1b9f7604d9a96b9556817ddcdb9b6ad/src-tauri/src/core/config.rs#L56-L68
resulting in colour scheme information not being saved.