### PR TITLE
Fix Default Line Width

### DIFF
--- a/src-tauri/src/core/config.rs
+++ b/src-tauri/src/core/config.rs
@@ -32,7 +32,7 @@ impl Default for CustomizeStyle {
       typeface: String::from("var(--sans-font)"),
       font_size: 14,
       line_height: 1.4,
-      line_width: 1,
+      line_width: 504,
     }
   }
 }

--- a/src-tauri/src/core/config.rs
+++ b/src-tauri/src/core/config.rs
@@ -32,7 +32,7 @@ impl Default for CustomizeStyle {
       typeface: String::from("var(--sans-font)"),
       font_size: 14,
       line_height: 1.4,
-      line_width: 504,
+      line_width: 648,
     }
   }
 }


### PR DESCRIPTION
fixes: #42 
fixes: #46 
fixes: #48

related PR: #43

This comment is incorrect: https://github.com/zhanglun/lettura/pull/43#issuecomment-2046965975

Although you set a default CSS value in the CSS itself, it is also set after loading the user config here:
https://github.com/zhanglun/lettura/blob/023d6fc7c90dd1c95dd43d817e92d09073a3c0e4/src/App.tsx#L52-L59

Since the default is set to 1, that is what is used when creating the initial `lettura.toml` file.
https://github.com/zhanglun/lettura/blob/023d6fc7c90dd1c95dd43d817e92d09073a3c0e4/src-tauri/src/core/config.rs#L29-L38

The new default value is taken from this piece of code:
https://github.com/zhanglun/lettura/blob/023d6fc7c90dd1c95dd43d817e92d09073a3c0e4/src/layout/Setting/CustomizeStyle/index.tsx#L20-L26

Without this change, ***every*** new user will face the issues linked in this PR.